### PR TITLE
Fix public payment intents

### DIFF
--- a/lib/GaletteStripe/Controllers/StripeController.php
+++ b/lib/GaletteStripe/Controllers/StripeController.php
@@ -260,6 +260,7 @@ class StripeController extends AbstractPluginController
                     return $response->withStatus(403);
                 }
 
+                $metadata['adherent_id'] = '';
                 $metadata['billing_name'] = $stripe_request['billing_firstname'] . ' ' . $stripe_request['billing_lastname'];
                 $metadata['billing_email'] = $stripe_request['billing_email'];
                 $metadata['billing_company'] = $stripe_request['billing_company'];


### PR DESCRIPTION
Empty `adherent_id` is required for public donations.