### PR TITLE
Drop the invoice event

### DIFF
--- a/lib/GaletteStripe/Controllers/StripeController.php
+++ b/lib/GaletteStripe/Controllers/StripeController.php
@@ -352,21 +352,8 @@ class StripeController extends AbstractPluginController
         // Process payload
         if (
             isset($post['type'])
-            && ($post['type'] == 'payment_intent.succeeded' || $post['type'] == 'invoice.payment_succeeded')
+            && ($post['type'] == 'payment_intent.succeeded')
         ) {
-            //We accept subscription invoice (annual or monthly) ; https://stripe.com/docs/billing/subscriptions/overview
-            //Todo : rewrite a more cleaner
-            if ($post['type'] == 'invoice.payment_succeeded') {
-                $post['data']['object']['metadata'] = array_merge($post['data']['object']['metadata'], $post['data']['object']['lines']['data'][0]['metadata']);
-                $post['data']['object']['amount_received'] = $post['data']['object']['amount_paid'];
-                $post['data']['object']['amount'] = $post['data']['object']['amount_due'];
-                $post['data']['object']['description'] = $post['data']['object']['lines']['data'][0]['metadata']['item_name'];
-
-                if ($post['data']['object']['status'] == 'paid') {
-                    $post['data']['object']['status'] = 'succeeded';
-                }
-            }
-
             $ph = new StripeHistory($this->zdb, $this->login, $this->preferences);
             $ph->add($post);
 

--- a/templates/default/stripe_preferences.html.twig
+++ b/templates/default/stripe_preferences.html.twig
@@ -43,8 +43,8 @@
                     <code>{{ webhook_url }}</code>
                 </div>
                 <div class="inline field">
-                    <label>{{ _T("Stripe Webhook events:", "stripe") }}</label>
-                    <code>payment_intent.succeeded</code> {{ _T("and") }} <code>invoice.payment_succeeded</code>
+                    <label>{{ _T("Stripe Webhook event:", "stripe") }}</label>
+                    <code>payment_intent.succeeded</code>
                 </div>
 
                 {% include "components/forms/text.html.twig" with {


### PR DESCRIPTION
I don't think this feature is achieved.

The intent was obviously to let users use the subscriptions and invoicing features directly on their Stripe dashboard which allow to send links to external payment forms to their contacts, and then track and use these payments in Galette.

In the actual state of code, it can only store succeeded payments in the plugin's log.

Corresponding contributions cannot be created in Galette because the request to the webhook doesn't transmit a member_id.

Moreover, the code doesn't handle the corresponding payments intents which are therefore filling up the plugin's logs with empty duplicated entries.

A better approach to implement (eventually) such a feature would be to use Stripe's SDK to create so called subscriptions from the plugin side and create the corresponding contribution with scheduled payments in Galette.