### PR TITLE
Display contribution types descriptions on form

### DIFF
--- a/templates/default/headers.html.twig
+++ b/templates/default/headers.html.twig
@@ -1,0 +1,21 @@
+{#
+/**
+ * Copyright © 2003-2025 The Galette Team
+ *
+ * This file is part of Galette Stripe plugin (https://galette-community.github.io/plugin-stripe).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette. If not, see <http://www.gnu.org/licenses/>.
+ */
+#}
+<link rel="stylesheet" type="text/css" href="{{ url_for("plugin_res", {"plugin": module_id, "path": "galette_stripe.css"}) }}"/>

--- a/templates/default/stripe_form.html.twig
+++ b/templates/default/stripe_form.html.twig
@@ -45,6 +45,9 @@
                                                 ({{ charged_amount|format_currency(stripe.getCurrency(), {}, galette_lang) }})
                                             </label>
                                         </div>
+                                        {% if amount['description'] is defined and amount['description'] is not empty %}
+                                            <div class="ui visible info message amount-description">{{ amount['description']|raw }}</div>
+                                        {% endif %}
                                     </div>
                                 {% endfor %}
                             </div>

--- a/webroot/galette_stripe.css
+++ b/webroot/galette_stripe.css
@@ -1,0 +1,3 @@
+.ui.message.amount-description {
+  margin-left:1.85714em;
+}


### PR DESCRIPTION
Depends on galette/galette#793
<img width="1004" height="457" alt="stripe" src="https://github.com/user-attachments/assets/afe24cb1-d195-4ef9-8a9e-840dd9fdde13" />
